### PR TITLE
basic goreleaser workflow implemented

### DIFF
--- a/.github/workflows/compile-binary.yaml
+++ b/.github/workflows/compile-binary.yaml
@@ -25,7 +25,7 @@ jobs:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
           version: latest
-          args: release --snapshot
+          args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CGO_ENABLED: 0


### PR DESCRIPTION
release binary as follow:
'''
git tag vx.x.x
git push origin vx.x.x
'''
