### PR TITLE
feat: add additional deployment statuses (upgrading & installing)

### DIFF
--- a/pkg/rasactl/list.go
+++ b/pkg/rasactl/list.go
@@ -73,7 +73,7 @@ func (r *RasaCtl) List() error {
 				rasaWorkerVersion = "0.0.0"
 			}
 
-			data = append(data, []string{current, namespace, string(status),
+			data = append(data, []string{current, namespace, status,
 				rasaProductionVersion,
 				rasaWorkerVersion,
 				enterprise,
@@ -81,7 +81,7 @@ func (r *RasaCtl) List() error {
 			},
 			)
 		} else {
-			data = append(data, []string{current, namespace, string(status),
+			data = append(data, []string{current, namespace, status,
 				"0.0.0",
 				"0.0.0",
 				string(stateData[types.StateEnterprise]),

--- a/pkg/rasactl/list.go
+++ b/pkg/rasactl/list.go
@@ -45,22 +45,10 @@ func (r *RasaCtl) List() error {
 		if err != nil {
 			r.Log.Info("Can't read a secret with state", "namespace", namespace, "error", err)
 		}
-		r.HelmClient.SetConfiguration(
-			&types.HelmConfigurationSpec{
-				ReleaseName: string(stateData[types.StateHelmReleaseName]),
-			},
-		)
-		r.KubernetesClient.SetHelmReleaseName(string(stateData[types.StateHelmReleaseName]))
-
-		isRunning, err := r.KubernetesClient.IsRasaXRunning()
+		status, _, err := r.GetReleaseStatus(stateData[types.StateHelmReleaseName])
 		if err != nil {
 			return err
 		}
-		status := "Stopped"
-		if isRunning {
-			status = "Running"
-		}
-
 		current := ""
 		if namespace == r.Namespace {
 			current = "*"

--- a/pkg/rasactl/list.go
+++ b/pkg/rasactl/list.go
@@ -73,7 +73,7 @@ func (r *RasaCtl) List() error {
 				rasaWorkerVersion = "0.0.0"
 			}
 
-			data = append(data, []string{current, namespace, status,
+			data = append(data, []string{current, namespace, string(status),
 				rasaProductionVersion,
 				rasaWorkerVersion,
 				enterprise,
@@ -81,7 +81,7 @@ func (r *RasaCtl) List() error {
 			},
 			)
 		} else {
-			data = append(data, []string{current, namespace, status,
+			data = append(data, []string{current, namespace, string(status),
 				"0.0.0",
 				"0.0.0",
 				string(stateData[types.StateEnterprise]),

--- a/pkg/rasactl/status.go
+++ b/pkg/rasactl/status.go
@@ -22,7 +22,6 @@ import (
 	"github.com/RasaHQ/rasactl/pkg/types"
 )
 
-
 // func (r *RasaCtl) GetReleaseStatus() (string, error) {
 // 	release, err := r.HelmClient.GetStatus()
 // 	if err != nil {
@@ -39,16 +38,13 @@ func (r *RasaCtl) Status() error {
 		return err
 	}
 
-	statusProject := "Stopped"
-
-	helmRelease, err := r.HelmClient.GetStatus()
-	if err != nil {
-		return err
-	}
-	statusProject = helmRelease.Info.Status.String()
-
-	if isRunning {
-		statusProject = "Running"
+	statusProject := "Running"
+	if !isRunning {
+		helmRelease, err := r.HelmClient.GetStatus()
+		if err != nil {
+			return err
+		}
+		statusProject = helmRelease.Info.Status.String()
 	}
 
 	stateData, err := r.KubernetesClient.ReadSecretWithState()

--- a/pkg/rasactl/status.go
+++ b/pkg/rasactl/status.go
@@ -75,8 +75,8 @@ func (r *RasaCtl) Status() error {
 	if err != nil {
 		return err
 	}
-	statusProject, release, err := r.GetReleaseStatus(stateData[types.StateHelmReleaseName])
 
+	statusProject, release, err := r.GetReleaseStatus(stateData[types.StateHelmReleaseName])
 	if err != nil {
 		return nil
 	}

--- a/pkg/rasactl/status.go
+++ b/pkg/rasactl/status.go
@@ -22,6 +22,15 @@ import (
 	"github.com/RasaHQ/rasactl/pkg/types"
 )
 
+
+// func (r *RasaCtl) GetReleaseStatus() (string, error) {
+// 	release, err := r.HelmClient.GetStatus()
+// 	if err != nil {
+// 			return "No status", err
+// 	}
+// 	return release.Info.Status.String(), err
+// }
+
 // Status prints status for a given deployment.
 func (r *RasaCtl) Status() error {
 	var d = [][]string{}
@@ -29,7 +38,15 @@ func (r *RasaCtl) Status() error {
 	if err != nil {
 		return err
 	}
+
 	statusProject := "Stopped"
+
+	helmRelease, err := r.HelmClient.GetStatus()
+	if err != nil {
+		return err
+	}
+	statusProject = helmRelease.Info.Status.String()
+
 	if isRunning {
 		statusProject = "Running"
 	}

--- a/pkg/rasactl/status.go
+++ b/pkg/rasactl/status.go
@@ -23,17 +23,15 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 )
 
-type StatusProject string
-
 const (
-	StatusStopped    StatusProject = "Stopped"
-	StatusRunning    StatusProject = "Running"
-	StatusInstalling StatusProject = "Installing"
-	StatusUpgrading  StatusProject = "Upgrading"
+	StatusStopped    = "Stopped"
+	StatusRunning    = "Running"
+	StatusInstalling = "Installing"
+	StatusUpgrading  = "Upgrading"
 )
 
-// Return project status, helm release, and err for a given helm release
-func (r *RasaCtl) GetReleaseStatus(releaseName []byte) (StatusProject, *release.Release, error) {
+// GetReleaseStatus returns project status, helm release, and err for a given helm release name
+func (r *RasaCtl) GetReleaseStatus(releaseName []byte) (string, *release.Release, error) {
 
 	status := StatusStopped
 
@@ -54,18 +52,18 @@ func (r *RasaCtl) GetReleaseStatus(releaseName []byte) (StatusProject, *release.
 	r.KubernetesClient.SetHelmReleaseName(string(releaseName))
 
 	release, err := r.HelmClient.GetStatus()
-
 	if err != nil {
 		return status, release, err
 	}
 
 	statusRelease := release.Info.Status.String()
-	if statusRelease == "pending-upgrade" {
+	switch statusRelease {
+	case "pending-upgrade":
 		status = StatusUpgrading
-	}
-	if statusRelease == "pending-install" {
+	case "pending-install":
 		status = StatusInstalling
 	}
+
 	return status, release, err
 }
 
@@ -84,7 +82,7 @@ func (r *RasaCtl) Status() error {
 	}
 
 	d = append(d, []string{"Name:", r.Namespace})
-	d = append(d, []string{"Status:", string(statusProject)})
+	d = append(d, []string{"Status:", statusProject})
 
 	url, err := r.GetRasaXURL()
 	if err != nil {


### PR DESCRIPTION
- #14 

- Added a new function to get the project status (stopped/running/installing/upgrading), which is called by `rasactl status/list`

Examples (highlighted as 👈) when the rasa-x deployment is 
- Installing
```console
❯ ./dist/rasactl list
CURRENT NAME    STATUS          RASA PRODUCTION RASA WORKER     ENTERPRISE      VERSION 
        rasa-x  Installing 👈     0.0.0           0.0.0                                  

❯ ./dist/rasactl status rasa-x -d
Name:                   rasa-x                         
Status:                 Installing                     
URL:                    http://rasa-x.rasactl.localhost
Version:                                               
Enterprise:                                            
Project path:           not defined                    
Helm chart:             rasa-x-2.11.0                  
Helm release:           rasa-x                         
Helm release status:    pending-install 👈               

NAME                                    CONDITION       STATUS  
rasa-x-app-85b6f789df-xw28h             NotReady        Pending
rasa-x-db-migration-service-0           NotReady        Pending
rasa-x-duckling-544b65cc49-2hdzp        NotReady        Pending
rasa-x-event-service-d6cf45696-gwnvf    NotReady        Pending
rasa-x-postgresql-0                     NotReady        Pending
rasa-x-rabbit-0                         NotReady        Pending
rasa-x-rasa-x-56bf7fdd44-9w69j          NotReady        Pending
rasa-x-redis-master-0                   NotReady        Pending
```
- upgrading
```console
❯ ./dist/rasactl list
CURRENT NAME            STATUS          RASA PRODUCTION RASA WORKER     ENTERPRISE      VERSION 
        kind-greider    Upgrading 👈      0.0.0           0.0.0                                  

❯ ./dist/rasactl status kind-greider -d
Name:                   kind-greider                         
Status:                 Upgrading                            
URL:                    http://kind-greider.rasactl.localhost
Version:                                                     
Enterprise:                                                  
Project path:           not defined                          
Helm chart:             rasa-x-2.11.0                        
Helm release:           rasa-x                               
Helm release status:    pending-upgrade 👈                     

NAME                                    CONDITION       STATUS  
rasa-x-app-85b6f789df-v7nvg             Ready           Running
rasa-x-db-migration-service-0           Ready           Running
rasa-x-duckling-544b65cc49-klmdh        Ready           Running
rasa-x-event-service-99648c8bd-mvk8k    Ready           Running
rasa-x-postgresql-0                     Ready           Running
rasa-x-rabbit-0                         Ready           Running
rasa-x-rasa-x-6cfd95c7d-2gh7q           Ready           Running
rasa-x-redis-master-0                   Ready           Running
```

