### PR TITLE
fix: Use local RASA X URL if it connects to local Rasa OSS

### DIFF
--- a/pkg/helm/default_values.go
+++ b/pkg/helm/default_values.go
@@ -165,13 +165,37 @@ func ValuesRabbitMQNodePort() map[string]interface{} {
 	return values
 }
 
-// ValuesPostgreSQLNodePort return helm vales which set the postgresql service type to NodePort.
+// ValuesPostgreSQLNodePort returns helm values which set the postgresql service type to NodePort.
 func ValuesPostgreSQLNodePort() map[string]interface{} {
 	values := map[string]interface{}{
 		"postgresql": map[string]interface{}{
 			"service": map[string]interface{}{
 				"type": "NodePort",
 			},
+		},
+	}
+
+	return values
+}
+
+// ValuesRasaXNodePort returns helm values which set the rasa-x service type to NodePort.
+func ValuesRasaXNodePort() map[string]interface{} {
+	values := map[string]interface{}{
+		"rasax": map[string]interface{}{
+			"service": map[string]interface{}{
+				"type": "NodePort",
+			},
+		},
+	}
+
+	return values
+}
+
+// ValuesSetRasaXHost returns helm values which set the RASA_X_HOST env variable for the rasa-x deployment.
+func ValuesSetRasaXHost(host string) map[string]interface{} {
+	values := map[string]interface{}{
+		"rasax": map[string]interface{}{
+			"overrideHost": host,
 		},
 	}
 

--- a/pkg/helm/fake/mock_client.go
+++ b/pkg/helm/fake/mock_client.go
@@ -7,10 +7,9 @@ package fake
 import (
 	reflect "reflect"
 
+	types "github.com/RasaHQ/rasactl/pkg/types"
 	gomock "github.com/golang/mock/gomock"
 	release "helm.sh/helm/v3/pkg/release"
-
-	types "github.com/RasaHQ/rasactl/pkg/types"
 )
 
 // MockInterface is a mock of Interface interface.

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -42,6 +42,7 @@ type KubernetesInterface interface {
 	GetPods() (*v1.PodList, error)
 	DeleteRasaXPods() error
 	GetPostgreSQLSvcNodePort() (int32, error)
+	GetRasaXSvcNodePort() (int32, error)
 	GetRabbitMqSvcNodePort() (int32, error)
 	SaveSecretWithState(projectPath string) error
 	UpdateRasaXConfig(token string) error
@@ -329,6 +330,18 @@ func (k *Kubernetes) DeleteRasaXPods() error {
 func (k *Kubernetes) GetPostgreSQLSvcNodePort() (int32, error) {
 
 	svcName := fmt.Sprintf("%s-postgresql", k.Helm.ReleaseName)
+	svc, err := k.clientset.CoreV1().Services(k.Namespace).Get(context.TODO(), svcName, metav1.GetOptions{})
+	if err != nil {
+		return 0, err
+	}
+
+	return svc.Spec.Ports[0].NodePort, nil
+}
+
+// GetRasaXSvcNodePort returns a node port for the postgresql service.
+func (k *Kubernetes) GetRasaXSvcNodePort() (int32, error) {
+
+	svcName := fmt.Sprintf("%s-rasa-x", k.Helm.ReleaseName)
 	svc, err := k.clientset.CoreV1().Services(k.Namespace).Get(context.TODO(), svcName, metav1.GetOptions{})
 	if err != nil {
 		return 0, err

--- a/pkg/k8s/fake/mock_client.go
+++ b/pkg/k8s/fake/mock_client.go
@@ -328,6 +328,21 @@ func (mr *MockKubernetesInterfaceMockRecorder) GetRabbitMqSvcNodePort() *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRabbitMqSvcNodePort", reflect.TypeOf((*MockKubernetesInterface)(nil).GetRabbitMqSvcNodePort))
 }
 
+// GetRasaXSvcNodePort mocks base method.
+func (m *MockKubernetesInterface) GetRasaXSvcNodePort() (int32, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRasaXSvcNodePort")
+	ret0, _ := ret[0].(int32)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRasaXSvcNodePort indicates an expected call of GetRasaXSvcNodePort.
+func (mr *MockKubernetesInterfaceMockRecorder) GetRasaXSvcNodePort() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRasaXSvcNodePort", reflect.TypeOf((*MockKubernetesInterface)(nil).GetRasaXSvcNodePort))
+}
+
 // GetRasaXToken mocks base method.
 func (m *MockKubernetesInterface) GetRasaXToken() (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/types/helm.go
+++ b/pkg/types/helm.go
@@ -22,7 +22,7 @@ const (
 	HelmChartNameRasaX string = "rasa-x"
 
 	//HelmChartVersionRasaX storage a version of helm chart used to deploy Rasa X / Enterprise.
-	HelmChartVersionRasaX string = "4.0.0"
+	HelmChartVersionRasaX string = "4.3.0"
 )
 
 // RepositorySpec stores data related to a helm repository.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -267,7 +267,7 @@ func GetPasswordStdin() (string, error) {
 // HelmChartVersionConstrains checks if the rasa-x-helm chart version
 // is within constraints boundaries.
 func HelmChartVersionConstrains(helmChartVersion string) error {
-	constraint := ">= 4.0.0, < 5.0.0"
+	constraint := fmt.Sprintf(">= %s, < 5.0.0", types.HelmChartVersionRasaX)
 
 	if helmChartVersion == "" {
 		return nil


### PR DESCRIPTION
If the `connect rasa` commend is used, the Rasa OSS should be able to connect to Rasa X by using a URL passed in a call. To achieve that, the rasa-x service has to be exposed on a NodePort and the `RASA_X_HOST` value in the rasa-x deployment has to be changed to point to ta URL that uses the NodePort.

Fixes #25 