### PR TITLE
fix(linux): [`connect rasa`] Use `hostAliases` for rasa-x pod instead of `extraHosts` for docker

### DIFF
--- a/pkg/docker/fake/mock_client.go
+++ b/pkg/docker/fake/mock_client.go
@@ -7,10 +7,9 @@ package fake
 import (
 	reflect "reflect"
 
+	docker "github.com/RasaHQ/rasactl/pkg/docker"
 	container "github.com/docker/docker/api/types/container"
 	gomock "github.com/golang/mock/gomock"
-
-	docker "github.com/RasaHQ/rasactl/pkg/docker"
 )
 
 // MockInterface is a mock of Interface interface.
@@ -77,6 +76,21 @@ func (m *MockInterface) GetKind() docker.KindSpec {
 func (mr *MockInterfaceMockRecorder) GetKind() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKind", reflect.TypeOf((*MockInterface)(nil).GetKind))
+}
+
+// GetKindNetworkGatewayAddress mocks base method.
+func (m *MockInterface) GetKindNetworkGatewayAddress() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKindNetworkGatewayAddress")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetKindNetworkGatewayAddress indicates an expected call of GetKindNetworkGatewayAddress.
+func (mr *MockInterfaceMockRecorder) GetKindNetworkGatewayAddress() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKindNetworkGatewayAddress", reflect.TypeOf((*MockInterface)(nil).GetKindNetworkGatewayAddress))
 }
 
 // SetKind mocks base method.

--- a/pkg/helm/default_values.go
+++ b/pkg/helm/default_values.go
@@ -202,6 +202,24 @@ func ValuesSetRasaXHost(host string) map[string]interface{} {
 	return values
 }
 
+// ValuesSetRasaXHostAliases returns helm vales which set hostAliases for the rasa-x deployment.
+func ValuesSetRasaXHostAliases(ipAddress string) map[string]interface{} {
+	values := map[string]interface{}{
+		"rasax": map[string]interface{}{
+			"hostAliases": []map[string]interface{}{
+				{
+					"ip": ipAddress,
+					"hostnames": []string{
+						"host.docker.internal",
+					},
+				},
+			},
+		},
+	}
+
+	return values
+}
+
 func valuesRabbitMQErlangCookie() map[string]interface{} {
 	values := map[string]interface{}{
 		"rabbitmq": map[string]interface{}{

--- a/pkg/k8s/configmap.go
+++ b/pkg/k8s/configmap.go
@@ -35,8 +35,8 @@ func (k *Kubernetes) UpdateRasaXConfig(token string) error {
 	if k.Flags.ConnectRasa.RunSeparateWorker {
 		workerPort++
 	}
-	urlProduction := fmt.Sprintf("http://gateway.docker.internal:%d", productionPort)
-	urlWorker := fmt.Sprintf("http://gateway.docker.internal:%d", workerPort)
+	urlProduction := fmt.Sprintf("http://host.docker.internal:%d", productionPort)
+	urlWorker := fmt.Sprintf("http://host.docker.internal:%d", workerPort)
 
 	configSpec := types.EnvironmentsConfigurationFile{
 		Rasa: types.RasaSpecEnvironments{

--- a/pkg/types/helm.go
+++ b/pkg/types/helm.go
@@ -22,7 +22,7 @@ const (
 	HelmChartNameRasaX string = "rasa-x"
 
 	//HelmChartVersionRasaX storage a version of helm chart used to deploy Rasa X / Enterprise.
-	HelmChartVersionRasaX string = "4.3.0"
+	HelmChartVersionRasaX string = "4.3.1"
 )
 
 // RepositorySpec stores data related to a helm repository.


### PR DESCRIPTION
- Use `hostAliases` for a rasa-x pod instead of `extraHosts` for docker under Linux.

Add the `host.docker.internal` host that points to a KinD network gateway to the `/etc/hosts` file by using `hostAliases` field in the rasa-x deployment - it's required only if a deployment runs on a Linux machine.

- A small refactor.