### PR TITLE
fix: Support for using different helm release name and versions

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -9,12 +9,12 @@ import (
 
 func addStartUpgradeFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(&helmConfiguration.Timeout, "wait-timeout", time.Minute*15, "time to wait for Rasa X to be ready")
-	cmd.Flags().StringVar(&helmConfiguration.Version, "rasa-x-chart-version", types.HelmChartVersionRasaX, "a helm chart version to use")
 	cmd.PersistentFlags().StringVar(&rasactlFlags.StartUpgrade.ValuesFile, "values-file", "", "absolute path to the values file")
 }
 
 func addStartFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&helmConfiguration.ReleaseName, "rasa-x-release-name", "rasa-x", "a helm release name to manage")
+	cmd.Flags().StringVar(&helmConfiguration.Version, "rasa-x-chart-version", types.HelmChartVersionRasaX, "a helm chart version to use")
 
 	cmd.PersistentFlags().StringVar(&rasactlFlags.Start.ProjectPath, "project-path", "",
 		"absolute path to the project directory mounted in kind")
@@ -33,6 +33,7 @@ func addStartFlags(cmd *cobra.Command) {
 
 func addUpgradeFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&helmConfiguration.Atomic, "atomic", false, "if set, upgrade process rolls back changes made in case of failed upgrade")
+	cmd.Flags().StringVar(&helmConfiguration.Version, "rasa-x-chart-version", "", "a helm chart version to use")
 	cmd.Flags().BoolVar(&helmConfiguration.ReuseValues, "reuse-values", true,
 		"when upgrading, reuse the last release's values and merge in any overrides")
 }

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/RasaHQ/rasactl/pkg/types"
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -43,7 +44,16 @@ func openCmd() *cobra.Command {
 			if err := checkIfNamespaceExists(); err != nil {
 				return err
 			}
-			rasaCtl.KubernetesClient.SetHelmReleaseName(helmConfiguration.ReleaseName)
+
+			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
+			if err != nil {
+				return errors.Errorf(errorPrint.Sprintf("%s", err))
+			}
+
+			helmReleaseName := string(stateData[types.StateHelmReleaseName])
+			rasaCtl.KubernetesClient.SetHelmReleaseName(helmReleaseName)
+
+			helmConfiguration.ReleaseName = helmReleaseName
 			rasaCtl.HelmClient.SetConfiguration(helmConfiguration)
 
 			return nil
@@ -66,7 +76,7 @@ func openCmd() *cobra.Command {
 			}
 
 			if err := browser.OpenURL(url); err != nil {
-				fmt.Printf("Can't open the URL using a web browser, go to the URL manually: %s ", url)
+				fmt.Printf("Can't open the URL using a web browser, go to the URL manually: %s\n", url)
 				return nil
 			}
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -65,6 +65,11 @@ func upgradeCmd() *cobra.Command {
 			if err != nil {
 				return errors.Errorf(errorPrint.Sprintf("%s", err))
 			}
+
+			if helmConfiguration.Version == "" {
+				helmConfiguration.Version = string(stateData[types.StateHelmChartVersion])
+			}
+
 			helmConfiguration.ReleaseName = string(stateData[types.StateHelmReleaseName])
 			rasaCtl.HelmClient.SetConfiguration(helmConfiguration)
 			rasaCtl.KubernetesClient.SetHelmReleaseName(string(stateData[types.StateHelmReleaseName]))

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -203,7 +203,7 @@ func (h *Helm) updateRepository() error {
 		re := re // create a new 're', https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {
 			if _, err := re.DownloadIndexFile(); err != nil {
-				return errors.Wrapf(err, "...Unable to get an update from the %q chart repository (%s):\n\t%s\n",
+				return errors.Wrapf(err, "...Unable to get an update from the %q chart repository (%s):\n\t%s",
 					re.Config.Name, re.Config.URL, err)
 			}
 			return nil

--- a/pkg/helm/install.go
+++ b/pkg/helm/install.go
@@ -53,6 +53,7 @@ func (h *Helm) Install() error {
 	client.Wait = true
 	client.DryRun = false
 	client.Timeout = h.Configuration.Timeout
+	client.Version = h.Configuration.Version
 
 	h.Log.V(1).Info("Helm client settings", "settings", client)
 

--- a/pkg/helm/upgrade.go
+++ b/pkg/helm/upgrade.go
@@ -49,6 +49,7 @@ func (h *Helm) Upgrade() error {
 	client.Timeout = h.Configuration.Timeout
 	client.Atomic = h.Configuration.Atomic
 	client.ReuseValues = h.Configuration.ReuseValues
+	client.Version = h.Configuration.Version
 	client.MaxHistory = 10
 
 	// In a case where deployment was stopped, and it's started again,

--- a/pkg/helm/utils_test.go
+++ b/pkg/helm/utils_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Utils", func() {
 					"rasax": map[string]interface{}{
 						"podLabels": map[string]interface{}{
 							"rasactl":       "true",
-							"test_template": float64(1),
+							"test_template": "1",
 							"test_version":  "0.0.0",
 						},
 					},

--- a/pkg/k8s/fake/mock_client.go
+++ b/pkg/k8s/fake/mock_client.go
@@ -11,6 +11,7 @@ import (
 	cloud "github.com/RasaHQ/rasactl/pkg/utils/cloud"
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
+	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -373,6 +374,21 @@ func (mr *MockKubernetesInterfaceMockRecorder) GetRasaXURL() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRasaXURL", reflect.TypeOf((*MockKubernetesInterface)(nil).GetRasaXURL))
 }
 
+// GetServiceWithLabels mocks base method.
+func (m *MockKubernetesInterface) GetServiceWithLabels(arg0 v10.ListOptions) (*v1.ServiceList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetServiceWithLabels", arg0)
+	ret0, _ := ret[0].(*v1.ServiceList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetServiceWithLabels indicates an expected call of GetServiceWithLabels.
+func (mr *MockKubernetesInterfaceMockRecorder) GetServiceWithLabels(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceWithLabels", reflect.TypeOf((*MockKubernetesInterface)(nil).GetServiceWithLabels), arg0)
+}
+
 // IsNamespaceExist mocks base method.
 func (m *MockKubernetesInterface) IsNamespaceExist(arg0 string) (bool, error) {
 	m.ctrl.T.Helper()
@@ -415,6 +431,20 @@ func (m *MockKubernetesInterface) IsRasaXRunning() (bool, error) {
 func (mr *MockKubernetesInterfaceMockRecorder) IsRasaXRunning() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRasaXRunning", reflect.TypeOf((*MockKubernetesInterface)(nil).IsRasaXRunning))
+}
+
+// IsSecretWithStateExist mocks base method.
+func (m *MockKubernetesInterface) IsSecretWithStateExist() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSecretWithStateExist")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSecretWithStateExist indicates an expected call of IsSecretWithStateExist.
+func (mr *MockKubernetesInterfaceMockRecorder) IsSecretWithStateExist() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSecretWithStateExist", reflect.TypeOf((*MockKubernetesInterface)(nil).IsSecretWithStateExist))
 }
 
 // LoadConfig mocks base method.

--- a/pkg/k8s/secrets.go
+++ b/pkg/k8s/secrets.go
@@ -96,6 +96,17 @@ func (k *Kubernetes) ReadSecretWithState() (map[string][]byte, error) {
 	return secret.Data, nil
 }
 
+// IsSecretWithStateExist checks if a state secret exists.
+// If the secret exists then return 'true'.
+func (k *Kubernetes) IsSecretWithStateExist() bool {
+
+	if _, err := k.ReadSecretWithState(); err != nil {
+		return false
+	}
+
+	return true
+}
+
 // DeleteSecretWithState deletes the rasactl secret.
 func (k *Kubernetes) DeleteSecretWithState() error {
 	err := k.clientset.CoreV1().Secrets(k.Namespace).Delete(context.TODO(),

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -203,3 +203,8 @@ func (k *Kubernetes) LoadConfig() (*rest.Config, error) {
 
 	return clientcmd.NewDefaultClientConfig(*rawConfig, nil).ClientConfig()
 }
+
+// GetServiceWithLabels returns a list of services with a given labels.
+func (k *Kubernetes) GetServiceWithLabels(opts metav1.ListOptions) (*v1.ServiceList, error) {
+	return k.clientset.CoreV1().Services(k.Namespace).List(context.TODO(), opts)
+}

--- a/pkg/rasactl/rasactl.go
+++ b/pkg/rasactl/rasactl.go
@@ -183,7 +183,7 @@ func (r *RasaCtl) useProject(projectPath string) error {
 			r.HelmClient.SetPersistanceVolumeClaimName(volume)
 
 		} else {
-			return errors.Errorf("It looks like you don't use kind as a current Kubernetes context, the project-path flag is supported only with kind.")
+			return errors.Errorf("It looks like you don't use kind as a current Kubernetes context, the project-path flag is supported only with kind")
 		}
 
 		if err := r.writeStatusFile(projectPath); err != nil {
@@ -301,8 +301,8 @@ func (r *RasaCtl) checkDeploymentStatus() error {
 	}
 
 	r.Log.Info("Rasa X is ready", "url", r.RasaXClient.URL, "password", r.Flags.Start.RasaXPassword)
-	r.Spinner.Message("Ready!")
 	r.Spinner.Stop()
+	fmt.Println("Ready!")
 
 	rasaXVersion, err := r.RasaXClient.GetVersionEndpoint()
 	if err != nil {

--- a/pkg/rasactl/stop.go
+++ b/pkg/rasactl/stop.go
@@ -51,7 +51,7 @@ func (r *RasaCtl) Stop() error {
 			return err
 		}
 	}
-	r.Spinner.Message(fmt.Sprintf("Rasa X for the %s deployment has been stopped", r.Namespace))
 	r.Spinner.Stop()
+	fmt.Printf("Rasa X for the %s deployment has been stopped\n", r.Namespace)
 	return nil
 }

--- a/pkg/status/spinner.go
+++ b/pkg/status/spinner.go
@@ -53,7 +53,6 @@ func (s *SpinnerMessage) Message(msg string) {
 
 func (s *SpinnerMessage) Stop() {
 	if s.spinner.Active() {
-		s.spinner.FinalMSG = "\n"
 		s.spinner.Stop()
 	}
 }

--- a/testdata/values.yaml
+++ b/testdata/values.yaml
@@ -2,4 +2,4 @@ rasax:
   podLabels:
     rasactl: "true"
     test_version: {{ env "RASACTL_TEST_VERSION" }}
-    test_template: {{ coalesce 0 1 2 }}
+    test_template: "{{ coalesce 0 1 2 }}"


### PR DESCRIPTION
Fixes:
- `connect rasa` - don't upgrade the helm chart version. One of the things that are executed during connecting Rasa OSS to Rasa X is upgrading a deployment with a configuration for Rasa OSS, before the fix, the helm chart version wasn't pinned and the latest available was used.
- `start` - don't upgrade the helm chart version if a deployment was previously stopped. Use the helm chart version from the state secret. 
-  `upgrade` - read a helm chart version from the state secret if the chart version is not passed via the `rasa-x-chart-version` flag.
- get Kubernetes services based on labels - previously a service name was used to get the service which didn't work if a helm release name was different than `rasa-x`.
- small fixes related to printing notifications.