### PR TITLE
fix: Return valid deployment status if a helm release name is different than the default

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,7 @@ linters-settings:
       - '^errors\.Wrap$'
       - '^errors\.Wrapf$'
       - '^fmt\.Errorf$'
+      - '^errors\.Errorf$'
 
   gci:
     local-prefixes: github.com/RasaHQ/rasactl

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
@@ -57,7 +57,7 @@ func addCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if _, err := parseArgs(namespace, args, 1, 1, rasactlFlags); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if err := checkIfNamespaceExists(); err != nil {
@@ -70,7 +70,7 @@ func addCmd() *cobra.Command {
 			}
 
 			if err := rasaCtl.Add(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			return nil

--- a/cmd/auth_login.go
+++ b/cmd/auth_login.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -74,7 +74,7 @@ func authLoginCmd() *cobra.Command {
 			}
 
 			if _, err := parseArgs(namespace, args, 1, 1, rasactlFlags); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if err := checkIfNamespaceExists(); err != nil {
@@ -83,7 +83,7 @@ func authLoginCmd() *cobra.Command {
 
 			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			rasaCtl.HelmClient.SetConfiguration(
 				&types.HelmConfigurationSpec{
@@ -96,13 +96,13 @@ func authLoginCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !rasaCtl.KubernetesClient.IsNamespaceManageable() {
-				return errors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
+				return xerrors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
 			}
 
 			// Check if a Rasa X deployment is already installed and running
 			_, isRunning, err := rasaCtl.CheckDeploymentStatus()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if !isRunning {
@@ -111,7 +111,7 @@ func authLoginCmd() *cobra.Command {
 			}
 
 			if err := rasaCtl.AuthLogin(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			return nil

--- a/cmd/auth_logout.go
+++ b/cmd/auth_logout.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -54,7 +54,7 @@ func authLogoutCmd() *cobra.Command {
 			}
 
 			if _, err := parseArgs(namespace, args, 1, 1, rasactlFlags); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if err := checkIfNamespaceExists(); err != nil {
@@ -62,7 +62,7 @@ func authLogoutCmd() *cobra.Command {
 			}
 			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			rasaCtl.HelmClient.SetConfiguration(
 				&types.HelmConfigurationSpec{
@@ -76,11 +76,11 @@ func authLogoutCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if !rasaCtl.KubernetesClient.IsNamespaceManageable() {
-				return errors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
+				return xerrors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
 			}
 
 			if err := rasaCtl.AuthLogout(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			fmt.Println("Successfully logged out.")

--- a/cmd/config_use_deployment.go
+++ b/cmd/config_use_deployment.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
@@ -45,7 +45,7 @@ func configUseDeploymentCmd() *cobra.Command {
 			}
 
 			if _, err := parseArgs(namespace, args, 1, 1, rasactlFlags); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			return checkIfNamespaceExists()
@@ -53,7 +53,7 @@ func configUseDeploymentCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if err := rasaCtl.ConfigUseDeployment(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			fmt.Printf("The current deployment has been set to %s.\n", rasaCtl.Namespace)

--- a/cmd/connect_rasa.go
+++ b/cmd/connect_rasa.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -62,7 +62,7 @@ func connectRasaCmd() *cobra.Command {
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 
 			if !utils.CommandExists("rasa") {
-				return errors.Errorf(
+				return xerrors.Errorf(
 					errorPrint.Sprint(
 						"The 'rasa' command doesn't exist. Check out the docs to learn how to install rasa, https://rasa.com/docs/rasa/installation/",
 					),
@@ -74,7 +74,7 @@ func connectRasaCmd() *cobra.Command {
 			}
 
 			if _, err := parseArgs(namespace, args, 1, 1, rasactlFlags); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if err := checkIfNamespaceExists(); err != nil {
@@ -83,7 +83,7 @@ func connectRasaCmd() *cobra.Command {
 
 			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			rasaCtl.HelmClient.SetConfiguration(
@@ -100,13 +100,13 @@ func connectRasaCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if !rasaCtl.KubernetesClient.IsNamespaceManageable() {
-				return errors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
+				return xerrors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
 			}
 
 			// Check if a Rasa X deployment is already installed and running
 			_, isRunning, err := rasaCtl.CheckDeploymentStatus()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if !isRunning {
@@ -115,7 +115,7 @@ func connectRasaCmd() *cobra.Command {
 			}
 
 			if err := rasaCtl.ConnectRasa(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			return nil

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -16,9 +16,9 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -58,12 +58,12 @@ func deleteCmd() *cobra.Command {
 			}
 
 			if !rasaCtl.KubernetesClient.IsNamespaceManageable() && !viper.GetBool("force") {
-				return errors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
+				return xerrors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
 			}
 
 			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			rasaCtl.HelmClient.SetConfiguration(
 				&types.HelmConfigurationSpec{
@@ -77,7 +77,7 @@ func deleteCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			defer rasaCtl.Spinner.Stop()
 			if err := rasaCtl.Delete(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			return nil
 		},

--- a/cmd/enterprise_activate.go
+++ b/cmd/enterprise_activate.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -59,7 +59,7 @@ func enterpriseActivateCmd() *cobra.Command {
 			}
 
 			if _, err := parseArgs(namespace, args, 1, 1, rasactlFlags); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if err := checkIfNamespaceExists(); err != nil {
@@ -68,7 +68,7 @@ func enterpriseActivateCmd() *cobra.Command {
 
 			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			rasaCtl.HelmClient.SetConfiguration(
 				&types.HelmConfigurationSpec{
@@ -81,13 +81,13 @@ func enterpriseActivateCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !rasaCtl.KubernetesClient.IsNamespaceManageable() {
-				return errors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
+				return xerrors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
 			}
 
 			// Check if a Rasa X deployment is already installed and running
 			_, isRunning, err := rasaCtl.CheckDeploymentStatus()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if !isRunning {
@@ -96,7 +96,7 @@ func enterpriseActivateCmd() *cobra.Command {
 			}
 
 			if err := rasaCtl.EnterpriseActivate(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			return nil

--- a/cmd/enterprise_deactivate.go
+++ b/cmd/enterprise_deactivate.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -53,7 +53,7 @@ func enterpriseDeactivateCmd() *cobra.Command {
 			}
 
 			if _, err := parseArgs(namespace, args, 1, 1, rasactlFlags); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if err := checkIfNamespaceExists(); err != nil {
@@ -62,7 +62,7 @@ func enterpriseDeactivateCmd() *cobra.Command {
 
 			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			rasaCtl.HelmClient.SetConfiguration(
 				&types.HelmConfigurationSpec{
@@ -75,13 +75,13 @@ func enterpriseDeactivateCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !rasaCtl.KubernetesClient.IsNamespaceManageable() {
-				return errors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
+				return xerrors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
 			}
 
 			// Check if a Rasa X deployment is already installed and running
 			_, isRunning, err := rasaCtl.CheckDeploymentStatus()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if !isRunning {
@@ -90,7 +90,7 @@ func enterpriseDeactivateCmd() *cobra.Command {
 			}
 
 			if err := rasaCtl.EnterpriseDeactivate(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			return nil

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -16,8 +16,8 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 )
 
 const (
@@ -49,11 +49,11 @@ func listCmd() *cobra.Command {
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if _, err := parseArgs(namespace, args, 0, 0, rasactlFlags); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if err := rasaCtl.List(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			return nil

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -68,7 +68,7 @@ func logsCmd() *cobra.Command {
 
 			args, err := parseArgs(namespace, args, 1, 2, rasactlFlags)
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			parsedArgs = args
 
@@ -78,7 +78,7 @@ func logsCmd() *cobra.Command {
 
 			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			rasaCtl.HelmClient.SetConfiguration(
 				&types.HelmConfigurationSpec{
@@ -93,7 +93,7 @@ func logsCmd() *cobra.Command {
 			// Check if a Rasa X deployment is running
 			_, isRunning, err := rasaCtl.CheckDeploymentStatus()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if !isRunning {
@@ -102,11 +102,11 @@ func logsCmd() *cobra.Command {
 			}
 
 			if !rasaCtl.KubernetesClient.IsNamespaceManageable() {
-				return errors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
+				return xerrors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
 			}
 
 			if err := rasaCtl.Logs(parsedArgs); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			return nil

--- a/cmd/model_delete.go
+++ b/cmd/model_delete.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -55,7 +55,7 @@ func modelDeleteCmd() *cobra.Command {
 
 			args, err := parseArgs(namespace, args, 1, 2, rasactlFlags)
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if err := checkIfNamespaceExists(); err != nil {
@@ -66,7 +66,7 @@ func modelDeleteCmd() *cobra.Command {
 
 			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			rasaCtl.HelmClient.SetConfiguration(
 				&types.HelmConfigurationSpec{
@@ -81,7 +81,7 @@ func modelDeleteCmd() *cobra.Command {
 			// Check if a Rasa X deployment is running
 			_, isRunning, err := rasaCtl.CheckDeploymentStatus()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if !isRunning {
@@ -90,11 +90,11 @@ func modelDeleteCmd() *cobra.Command {
 			}
 
 			if !rasaCtl.KubernetesClient.IsNamespaceManageable() {
-				return errors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
+				return xerrors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
 			}
 
 			if err := rasaCtl.ModelDelete(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			return nil

--- a/cmd/model_download.go
+++ b/cmd/model_download.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -56,7 +56,7 @@ func modelDownloadCmd() *cobra.Command {
 
 			args, err := parseArgs(namespace, args, 1, 3, rasactlFlags)
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if err := checkIfNamespaceExists(); err != nil {
@@ -68,7 +68,7 @@ func modelDownloadCmd() *cobra.Command {
 
 			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			rasaCtl.HelmClient.SetConfiguration(
 				&types.HelmConfigurationSpec{
@@ -84,7 +84,7 @@ func modelDownloadCmd() *cobra.Command {
 			// Check if a Rasa X deployment is running
 			_, isRunning, err := rasaCtl.CheckDeploymentStatus()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if !isRunning {
@@ -93,11 +93,11 @@ func modelDownloadCmd() *cobra.Command {
 			}
 
 			if !rasaCtl.KubernetesClient.IsNamespaceManageable() {
-				return errors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
+				return xerrors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
 			}
 
 			if err := rasaCtl.ModelDownload(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			return nil

--- a/cmd/model_list.go
+++ b/cmd/model_list.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -54,7 +54,7 @@ func modelListCmd() *cobra.Command {
 			}
 
 			if _, err := parseArgs(namespace, args, 1, 1, rasactlFlags); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if err := checkIfNamespaceExists(); err != nil {
@@ -63,7 +63,7 @@ func modelListCmd() *cobra.Command {
 
 			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			rasaCtl.HelmClient.SetConfiguration(
 				&types.HelmConfigurationSpec{
@@ -79,7 +79,7 @@ func modelListCmd() *cobra.Command {
 			// Check if a Rasa X deployment is running
 			_, isRunning, err := rasaCtl.CheckDeploymentStatus()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if !isRunning {
@@ -88,11 +88,11 @@ func modelListCmd() *cobra.Command {
 			}
 
 			if !rasaCtl.KubernetesClient.IsNamespaceManageable() {
-				return errors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
+				return xerrors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
 			}
 
 			if err := rasaCtl.ModelList(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			return nil

--- a/cmd/model_tag.go
+++ b/cmd/model_tag.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -62,7 +62,7 @@ func modelTagCmd() *cobra.Command {
 
 			args, err := parseArgs(namespace, args, 2, 3, rasactlFlags)
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			modelName := args[1]
@@ -77,7 +77,7 @@ func modelTagCmd() *cobra.Command {
 
 			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			rasaCtl.HelmClient.SetConfiguration(
 				&types.HelmConfigurationSpec{
@@ -92,7 +92,7 @@ func modelTagCmd() *cobra.Command {
 			// Check if a Rasa X deployment is running
 			_, isRunning, err := rasaCtl.CheckDeploymentStatus()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if !isRunning {
@@ -101,11 +101,11 @@ func modelTagCmd() *cobra.Command {
 			}
 
 			if !rasaCtl.KubernetesClient.IsNamespaceManageable() {
-				return errors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
+				return xerrors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
 			}
 
 			if err := rasaCtl.ModelTag(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			return nil

--- a/cmd/model_upload.go
+++ b/cmd/model_upload.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -55,7 +55,7 @@ func modelUploadCmd() *cobra.Command {
 
 			args, err := parseArgs(namespace, args, 1, 2, rasactlFlags)
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if err := checkIfNamespaceExists(); err != nil {
@@ -66,7 +66,7 @@ func modelUploadCmd() *cobra.Command {
 
 			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			rasaCtl.HelmClient.SetConfiguration(
 				&types.HelmConfigurationSpec{
@@ -81,7 +81,7 @@ func modelUploadCmd() *cobra.Command {
 			// Check if a Rasa X deployment is running
 			_, isRunning, err := rasaCtl.CheckDeploymentStatus()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if !isRunning {
@@ -90,11 +90,11 @@ func modelUploadCmd() *cobra.Command {
 			}
 
 			if !rasaCtl.KubernetesClient.IsNamespaceManageable() {
-				return errors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
+				return xerrors.Errorf(errorPrint.Sprintf("The %s namespace exists but is not managed by rasactl, can't continue :(", rasaCtl.Namespace))
 			}
 
 			if err := rasaCtl.ModelUpload(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			return nil

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 
 	"github.com/pkg/browser"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
 )
@@ -39,7 +39,7 @@ func openCmd() *cobra.Command {
 			}
 
 			if _, err := parseArgs(namespace, args, 1, 1, rasactlFlags); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if err := checkIfNamespaceExists(); err != nil {
@@ -48,7 +48,7 @@ func openCmd() *cobra.Command {
 
 			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			helmReleaseName := string(stateData[types.StateHelmReleaseName])
@@ -63,7 +63,7 @@ func openCmd() *cobra.Command {
 			// Check if a Rasa X deployment is already installed and running
 			_, isRunning, err := rasaCtl.CheckDeploymentStatus()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if !isRunning {
@@ -73,7 +73,7 @@ func openCmd() *cobra.Command {
 
 			url, err := rasaCtl.GetRasaXURL()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if err := browser.OpenURL(url); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,9 +24,9 @@ import (
 	"github.com/fatih/color"
 	"github.com/go-logr/logr"
 	homedir "github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/xerrors"
 
 	"github.com/RasaHQ/rasactl/pkg/logger"
 	"github.com/RasaHQ/rasactl/pkg/rasactl"
@@ -61,7 +61,7 @@ var rootCmd = &cobra.Command{
 
 		if !strings.Contains(cmd.CommandPath(), "help") && !strings.Contains(cmd.CommandPath(), "completion") {
 			if err := rasaCtl.InitClients(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 		}
 		return nil

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -84,13 +84,13 @@ func startCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if _, err := parseArgs(namespace, args, 1, 1, rasactlFlags); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			// Get list of namespaces (deployments)
 			namespaces, err := rasaCtl.KubernetesClient.GetNamespaces()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprint(err))
+				return xerrors.Errorf(errorPrint.Sprint(err))
 			}
 
 			// Check if namespace exists only if the number of namespaces >= 2
@@ -105,7 +105,7 @@ func startCmd() *cobra.Command {
 			if rasaCtl.KubernetesClient.IsSecretWithStateExist() {
 				stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 				if err != nil {
-					return errors.Errorf(errorPrint.Sprintf("%s", err))
+					return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 				}
 
 				helmConfiguration.ReleaseName = string(stateData[types.StateHelmReleaseName])
@@ -116,7 +116,7 @@ func startCmd() *cobra.Command {
 
 			_, isRunning, err := rasaCtl.CheckDeploymentStatus()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if isRunning {
@@ -125,7 +125,7 @@ func startCmd() *cobra.Command {
 			}
 			defer rasaCtl.Spinner.Stop()
 			if err := rasaCtl.Start(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			return nil
 		},

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -67,7 +67,7 @@ func stopCmd() *cobra.Command {
 
 			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			rasaCtl.HelmClient.SetConfiguration(
 				&types.HelmConfigurationSpec{
@@ -82,7 +82,7 @@ func stopCmd() *cobra.Command {
 			// Check if a Rasa X deployment is already installed and running
 			_, isRunning, err := rasaCtl.CheckDeploymentStatus()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if !isRunning {
@@ -92,7 +92,7 @@ func stopCmd() *cobra.Command {
 			defer rasaCtl.Spinner.Stop()
 
 			if err := rasaCtl.Stop(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			return nil
 		},

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -18,8 +18,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -54,7 +54,7 @@ func upgradeCmd() *cobra.Command {
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			utils.CheckHelmChartDir()
 			if _, err := parseArgs(namespace, args, 1, 1, rasactlFlags); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if err := checkIfNamespaceExists(); err != nil {
@@ -63,7 +63,7 @@ func upgradeCmd() *cobra.Command {
 
 			stateData, err := rasaCtl.KubernetesClient.ReadSecretWithState()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if helmConfiguration.Version == "" {
@@ -80,7 +80,7 @@ func upgradeCmd() *cobra.Command {
 			// Check if a Rasa X deployment is already installed and running
 			_, isRunning, err := rasaCtl.CheckDeploymentStatus()
 			if err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 
 			if !isRunning {
@@ -89,7 +89,7 @@ func upgradeCmd() *cobra.Command {
 			}
 
 			if err := rasaCtl.Upgrade(); err != nil {
-				return errors.Errorf(errorPrint.Sprintf("%s", err))
+				return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 			}
 			rasaCtl.Spinner.Message("Ready!")
 			defer rasaCtl.Spinner.Stop()

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/kyokomi/emoji"
-	"github.com/pkg/errors"
 	"golang.org/x/xerrors"
 
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -34,16 +33,16 @@ func runOnClose(signal os.Signal) {
 
 func checkIfNamespaceExists() error {
 	if namespace == "" {
-		return errors.Errorf(errorPrint.Sprint("You have to pass a deployment name"))
+		return xerrors.Errorf(errorPrint.Sprint("You have to pass a deployment name"))
 	}
 
 	isNamespaceExist, err := rasaCtl.KubernetesClient.IsNamespaceExist(rasaCtl.Namespace)
 	if err != nil {
-		return errors.Errorf(errorPrint.Sprintf("%s", err))
+		return xerrors.Errorf(errorPrint.Sprintf("%s", err))
 	}
 
 	if !isNamespaceExist {
-		return errors.Errorf(errorPrint.Sprintf("The %s deployment doesn't exist.\n", rasaCtl.Namespace))
+		return xerrors.Errorf(errorPrint.Sprintf("The %s deployment doesn't exist.\n", rasaCtl.Namespace))
 	}
 	return nil
 }
@@ -51,11 +50,11 @@ func checkIfNamespaceExists() error {
 func checkIfDeploymentsExist() error {
 	namespaces, err := rasaCtl.KubernetesClient.GetNamespaces()
 	if err != nil {
-		return errors.Errorf(errorPrint.Sprint(err))
+		return xerrors.Errorf(errorPrint.Sprint(err))
 	}
 
 	if len(namespaces) == 0 {
-		return errors.Errorf(errorPrint.Sprint("No deployments, use the 'rasactl start' command to create one."))
+		return xerrors.Errorf(errorPrint.Sprint("No deployments, use the 'rasactl start' command to create one."))
 	}
 	return nil
 }
@@ -69,7 +68,7 @@ func parseArgs(currentNamespace string, args []string, minArgs, maxArgs int, fla
 
 	namespaces, err := rasaCtl.KubernetesClient.GetNamespaces()
 	if err != nil {
-		return nil, errors.Errorf(errorPrint.Sprint(err))
+		return nil, xerrors.Errorf(errorPrint.Sprint(err))
 	}
 
 	numNamespaces := len(namespaces)

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -33,7 +33,7 @@ import (
 	"github.com/docker/docker/pkg/archive"
 	"github.com/ghodss/yaml"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4"
@@ -263,7 +263,7 @@ func (d *Docker) joinKindNodeToKubernetesCluster(container container.ContainerCr
 		}
 		d.Log.Info("Waiting for kind node to join to the cluster", "container", container.ID, "running", status.Running, "exitCode", status.ExitCode)
 		if status.ExitCode != 0 {
-			return errors.Errorf("Can't join kind node to the cluster")
+			return xerrors.Errorf("Can't join kind node to the cluster")
 		}
 		if !status.Running {
 			break

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -284,7 +284,13 @@ func (k *Kubernetes) GetRasaXToken() (string, error) {
 
 // IsRasaXRunning checks if Rasa X deployment is running.
 func (k *Kubernetes) IsRasaXRunning() (bool, error) {
-	deployments, err := k.clientset.AppsV1().Deployments(k.Namespace).List(context.TODO(), metav1.ListOptions{})
+	labels := fmt.Sprintf("app.kubernetes.io/instance=%s", k.Helm.ReleaseName)
+
+	k.Log.V(1).Info("Getting deployments list", "labels", labels)
+
+	deployments, err := k.clientset.AppsV1().Deployments(k.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels,
+	})
 	if err != nil {
 		return false, err
 	}
@@ -301,7 +307,11 @@ func (k *Kubernetes) IsRasaXRunning() (bool, error) {
 		}
 	}
 
-	statefulsets, err := k.clientset.AppsV1().StatefulSets(k.Namespace).List(context.TODO(), metav1.ListOptions{})
+	k.Log.V(1).Info("Getting statefulsets list", "labels", labels)
+
+	statefulsets, err := k.clientset.AppsV1().StatefulSets(k.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels,
+	})
 	if err != nil {
 		return false, err
 	}
@@ -348,7 +358,11 @@ func (k *Kubernetes) CreateNamespace() error {
 
 // GetPods returns a list of pods for the active namespace.
 func (k *Kubernetes) GetPods() (*v1.PodList, error) {
-	pods, err := k.clientset.CoreV1().Pods(k.Namespace).List(context.TODO(), metav1.ListOptions{})
+	labels := fmt.Sprintf("app.kubernetes.io/instance=%s", k.Helm.ReleaseName)
+
+	pods, err := k.clientset.CoreV1().Pods(k.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -356,7 +370,11 @@ func (k *Kubernetes) GetPods() (*v1.PodList, error) {
 }
 
 func (k *Kubernetes) DeleteRasaXPods() error {
-	pods, err := k.clientset.CoreV1().Pods(k.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: "app.kubernetes.io/component=rasa-x"})
+	labels := fmt.Sprintf("app.kubernetes.io/component=rasa-x,app.kubernetes.io/instance=%s", k.Helm.ReleaseName)
+
+	pods, err := k.clientset.CoreV1().Pods(k.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/k8s/scale.go
+++ b/pkg/k8s/scale.go
@@ -17,6 +17,7 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,7 +25,11 @@ import (
 
 // ScaleDown scales down all deployments and statefulsets for a given deployment.
 func (k *Kubernetes) ScaleDown() error {
-	deployments, err := k.clientset.AppsV1().Deployments(k.Namespace).List(context.TODO(), metav1.ListOptions{})
+	labels := fmt.Sprintf("app.kubernetes.io/instance=%s", k.Helm.ReleaseName)
+
+	deployments, err := k.clientset.AppsV1().Deployments(k.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels,
+	})
 	if err != nil {
 		return err
 	}
@@ -45,7 +50,9 @@ func (k *Kubernetes) ScaleDown() error {
 		}
 	}
 
-	statefulsets, err := k.clientset.AppsV1().StatefulSets(k.Namespace).List(context.TODO(), metav1.ListOptions{})
+	statefulsets, err := k.clientset.AppsV1().StatefulSets(k.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels,
+	})
 	if err != nil {
 		return err
 	}
@@ -71,7 +78,11 @@ func (k *Kubernetes) ScaleDown() error {
 
 // ScaleDown scales up all deployments and statefulsets for a given deployment.
 func (k *Kubernetes) ScaleUp() error {
-	deployments, err := k.clientset.AppsV1().Deployments(k.Namespace).List(context.TODO(), metav1.ListOptions{})
+	labels := fmt.Sprintf("app.kubernetes.io/instance=%s", k.Helm.ReleaseName)
+
+	deployments, err := k.clientset.AppsV1().Deployments(k.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels,
+	})
 	if err != nil {
 		return err
 	}
@@ -96,7 +107,9 @@ func (k *Kubernetes) ScaleUp() error {
 		}
 	}
 
-	statefulsets, err := k.clientset.AppsV1().StatefulSets(k.Namespace).List(context.TODO(), metav1.ListOptions{})
+	statefulsets, err := k.clientset.AppsV1().StatefulSets(k.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/rasactl/connect_rasa.go
+++ b/pkg/rasactl/connect_rasa.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v2"
 
 	"github.com/RasaHQ/rasactl/pkg/helm"
@@ -41,7 +41,7 @@ import (
 func (r *RasaCtl) ConnectRasa() error {
 
 	if r.KubernetesClient.GetBackendType() != types.KubernetesBackendLocal {
-		return errors.Errorf(
+		return xerrors.Errorf(
 			"It looks like you're not using kind as a backend for Kubernetes cluster, this command is available only if you use kind",
 		)
 	}

--- a/pkg/rasactl/list.go
+++ b/pkg/rasactl/list.go
@@ -45,10 +45,14 @@ func (r *RasaCtl) List() error {
 		if err != nil {
 			r.Log.Info("Can't read a secret with state", "namespace", namespace, "error", err)
 		}
-		status, _, err := r.GetReleaseStatus(stateData[types.StateHelmReleaseName])
+
+		releaseName := string(stateData[types.StateHelmReleaseName])
+		r.KubernetesClient.SetHelmReleaseName(releaseName)
+		status, _, err := r.GetReleaseStatus(releaseName)
 		if err != nil {
 			return err
 		}
+
 		current := ""
 		if namespace == r.Namespace {
 			current = "*"

--- a/pkg/rasactl/rasactl.go
+++ b/pkg/rasactl/rasactl.go
@@ -20,7 +20,7 @@ import (
 	"os"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 
 	"github.com/RasaHQ/rasactl/pkg/docker"
 	"github.com/RasaHQ/rasactl/pkg/helm"
@@ -157,7 +157,7 @@ func (r *RasaCtl) useProject(projectPath string) error {
 					if os.IsNotExist(err) {
 						return err
 					} else if !path.IsDir() {
-						return errors.Errorf("The %s path can't point to a file, it has to be a directory", projectPath)
+						return xerrors.Errorf("The %s path can't point to a file, it has to be a directory", projectPath)
 					}
 					return err
 				}
@@ -183,7 +183,7 @@ func (r *RasaCtl) useProject(projectPath string) error {
 			r.HelmClient.SetPersistanceVolumeClaimName(volume)
 
 		} else {
-			return errors.Errorf("It looks like you don't use kind as a current Kubernetes context, the project-path flag is supported only with kind")
+			return xerrors.Errorf("It looks like you don't use kind as a current Kubernetes context, the project-path flag is supported only with kind")
 		}
 
 		if err := r.writeStatusFile(projectPath); err != nil {

--- a/pkg/rasactl/status.go
+++ b/pkg/rasactl/status.go
@@ -32,7 +32,7 @@ const (
 )
 
 // GetReleaseStatus returns project status, helm release, and err for a given helm release name
-func (r *RasaCtl) GetReleaseStatus(releaseName []byte) (string, *release.Release, error) {
+func (r *RasaCtl) GetReleaseStatus(releaseName string) (string, *release.Release, error) {
 
 	status := StatusStopped
 
@@ -47,10 +47,9 @@ func (r *RasaCtl) GetReleaseStatus(releaseName []byte) (string, *release.Release
 
 	r.HelmClient.SetConfiguration(
 		&types.HelmConfigurationSpec{
-			ReleaseName: string(releaseName),
+			ReleaseName: releaseName,
 		},
 	)
-	r.KubernetesClient.SetHelmReleaseName(string(releaseName))
 
 	release, err := r.HelmClient.GetStatus()
 	if err != nil {
@@ -77,7 +76,7 @@ func (r *RasaCtl) Status() error {
 		return err
 	}
 
-	statusProject, release, err := r.GetReleaseStatus(stateData[types.StateHelmReleaseName])
+	statusProject, release, err := r.GetReleaseStatus(string(stateData[types.StateHelmReleaseName]))
 	if err != nil {
 		return nil
 	}

--- a/pkg/rasax/auth.go
+++ b/pkg/rasax/auth.go
@@ -22,7 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 
 	rtypes "github.com/RasaHQ/rasactl/pkg/types/rasax"
 )
@@ -60,10 +60,10 @@ func (r *RasaX) Auth(username, password string) (*rtypes.AuthEndpointResponse, e
 		return bodyData, nil
 
 	case 401:
-		return nil, errors.Errorf("Unauthorized")
+		return nil, xerrors.Errorf("Unauthorized")
 
 	default:
-		return nil, errors.Errorf("The Rasa X health endpoint has returned status code %s", resp.Status)
+		return nil, xerrors.Errorf("The Rasa X health endpoint has returned status code %s", resp.Status)
 	}
 }
 

--- a/pkg/rasax/client.go
+++ b/pkg/rasax/client.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 
 	"github.com/RasaHQ/rasactl/pkg/status"
 	"github.com/RasaHQ/rasactl/pkg/types"
@@ -107,7 +107,7 @@ func (r *RasaX) GetHealthEndpoint() (*rtypes.HealthEndpointsResponse, error) {
 		return bodyData, nil
 
 	}
-	return nil, errors.Errorf("The Rasa X health endpoint has returned status code %s", resp.Status)
+	return nil, xerrors.Errorf("The Rasa X health endpoint has returned status code %s", resp.Status)
 }
 
 func (r *RasaX) GetVersionEndpoint() (*rtypes.VersionEndpointResponse, error) {
@@ -135,5 +135,5 @@ func (r *RasaX) GetVersionEndpoint() (*rtypes.VersionEndpointResponse, error) {
 		return bodyData, nil
 
 	}
-	return nil, errors.Errorf("The Rasa X health endpoint has returned status code %s", resp.Status)
+	return nil, xerrors.Errorf("The Rasa X health endpoint has returned status code %s", resp.Status)
 }

--- a/pkg/rasax/enterprise.go
+++ b/pkg/rasax/enterprise.go
@@ -22,7 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 // EnterpriseActivate activates an Enterprise license via the /api/license endpoint.
@@ -56,11 +56,11 @@ func (r *RasaX) EnterpriseActivate(license string) error {
 		return nil
 
 	case 401:
-		return errors.Errorf("Unauthorized")
+		return xerrors.Errorf("Unauthorized")
 
 	default:
 		content, _ := ioutil.ReadAll(resp.Body)
-		return errors.Errorf("The Rasa X license endpoint has returned status code %s, body: %s", resp.Status, content)
+		return xerrors.Errorf("The Rasa X license endpoint has returned status code %s, body: %s", resp.Status, content)
 	}
 }
 
@@ -89,10 +89,10 @@ func (r *RasaX) EnterpriseDeactivate() error {
 		return nil
 
 	case 401:
-		return errors.Errorf("Unauthorized")
+		return xerrors.Errorf("Unauthorized")
 
 	default:
 		content, _ := ioutil.ReadAll(resp.Body)
-		return errors.Errorf("The Rasa X license endpoint has returned status code %s, body: %s", resp.Status, content)
+		return xerrors.Errorf("The Rasa X license endpoint has returned status code %s, body: %s", resp.Status, content)
 	}
 }

--- a/pkg/rasax/status.go
+++ b/pkg/rasax/status.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/xerrors"
 
 	types "github.com/RasaHQ/rasactl/pkg/types/rasax"
 )
@@ -31,7 +31,7 @@ func (r *RasaX) WaitForDatabaseMigration(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.Errorf("Error while waiting for Rasa X Database migration status, error: %s", ctx.Err())
+			return xerrors.Errorf("Error while waiting for Rasa X Database migration status, error: %s", ctx.Err())
 		default:
 			healthStatus, err := r.GetHealthEndpoint()
 			if healthStatus == nil || err != nil {
@@ -64,7 +64,7 @@ func (r *RasaX) WaitForRasaServer(ctx context.Context, environment string) error
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.Errorf("Error while waiting for Rasa worker status, error: %s", ctx.Err())
+			return xerrors.Errorf("Error while waiting for Rasa worker status, error: %s", ctx.Err())
 		default:
 
 			healthStatus, err := r.GetHealthEndpoint()

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -81,7 +81,7 @@ func MergeMaps(maps ...map[string]interface{}) map[string]interface{} {
 func ValidateName(name string) error {
 
 	if !validName.MatchString(name) {
-		return errors.Errorf(
+		return xerrors.Errorf(
 			"Invalid name: \"%s\": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', "+
 				"and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '%s')",
 			name, validName.String())


### PR DESCRIPTION
- A deployment status returned by the `list` and `status` commands is invalid if a helm release name of a given deployment is different from the default name.
- A small refactor (replace `errors` package with `xerrors`)