### PR TITLE
feat: set random password as default

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -23,7 +23,7 @@ func addStartFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVarP(&rasactlFlags.Start.Project, "project", "p", false,
 		"use the current working directory as a project directory, the flag is ignored if --project-path is used")
 
-	cmd.PersistentFlags().StringVar(&rasactlFlags.Start.RasaXPassword, "rasa-x-password", "rasaxlocal", "Rasa X password")
+	cmd.PersistentFlags().StringVar(&rasactlFlags.Start.RasaXPassword, "rasa-x-password", "", "Rasa X password")
 	cmd.PersistentFlags().BoolVar(&rasactlFlags.Start.RasaXPasswordStdin, "rasa-x-password-stdin", false, "read the Rasa X password from stdin")
 	cmd.Flags().BoolVar(&rasactlFlags.Start.UseEdgeRelease, "rasa-x-edge-release", false, "use the latest edge release of Rasa X")
 	cmd.Flags().BoolVar(&rasactlFlags.Start.Create, "create", false,

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -81,7 +81,10 @@ func startCmd() *cobra.Command {
 			}
 
 			if rasactlFlags.Start.RasaXPassword == "" {
-				password := utils.GenerateRandomPassword(14)
+				password, err := utils.GenerateRandomPassword(14)
+				if err != nil {
+					return err
+				}
 				rasactlFlags.Start.RasaXPassword = password
 			}
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -80,6 +80,11 @@ func startCmd() *cobra.Command {
 				rasactlFlags.Start.RasaXPassword = password
 			}
 
+			if rasactlFlags.Start.RasaXPassword == "" {
+				password := utils.GenerateRandomPassword(14)
+				rasactlFlags.Start.RasaXPassword = password
+			}
+
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -263,6 +264,24 @@ func GetPasswordStdin() (string, error) {
 		return line, err
 	}
 	return strings.TrimSuffix(line, "\n"), nil
+}
+
+// GenerateRandomPassword generates random ASCII password
+func GenerateRandomPassword(length int) string {
+	rand.Seed(time.Now().UnixNano())
+	const (
+		lowerLetters = "abcdefghijklmnopqrstuvwxyz"
+		upperLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		digits       = "0123456789"
+		symbols      = "!@#$&*()_+-="
+		all          = lowerLetters + upperLetters + digits + symbols
+	)
+	password := make([]byte, length)
+	for i := range password {
+		password[i] = all[rand.Intn(len(all))]
+	}
+
+	return string(password)
 }
 
 // HelmChartVersionConstrains checks if the rasa-x-helm chart version

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Utils", func() {
 		Expect(str).To(Equal("{\"test\":\"test\"}"))
 	})
 
-	It("check password length", func() {
+	It("check password generator", func() {
 		length := 14
 
 		password, err := utils.GenerateRandomPassword(length)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -57,6 +57,15 @@ var _ = Describe("Utils", func() {
 		Expect(str).To(Equal("{\"test\":\"test\"}"))
 	})
 
+	It("check password length", func() {
+		length := 14
+
+		password, err := utils.GenerateRandomPassword(length)
+		Expect(password).To(HaveLen(length))
+		Expect(password).To(BeAssignableToTypeOf("string"))
+		Expect(err).To(BeNil())
+	})
+
 	Describe("read Rasa X URL from environment variables", func() {
 		viper.AutomaticEnv() // read in environment variables that match
 		viper.SetEnvPrefix("rasactl")


### PR DESCRIPTION
`rasactl` create new deployments with a hardcoded password (rasaxlocal). Leaving new installation open to be compromised.

**Solution**
If `--rasa-x-password` flag is not used, generate a random password.